### PR TITLE
Sanitizing invalid literal text string

### DIFF
--- a/packet/parser_test.go
+++ b/packet/parser_test.go
@@ -285,7 +285,7 @@ const (
 		Literal Data Packet (tag 11) (19 bytes)
 			62 00 5a 19 0d e4 48 65 6c 6c 6f 20 77 6f 72 6c 64 0d 0a
 			Literal data format: b (binary)
-			File name: <null>
+			File name (0 byte)
 			Modification time of a file: 2017-11-25T06:29:56Z
 				5a 19 0d e4
 			Literal data (13 bytes)

--- a/packet/tags/sub06.go
+++ b/packet/tags/sub06.go
@@ -19,9 +19,7 @@ func newSub06(cxt *context.Context, subID values.SuboacketID, body []byte) Subs 
 
 // Parse parsing Regular Expression Sub-packet
 func (s *sub06) Parse() (*info.Item, error) {
-	rootInfo := s.ToItem()
-	rootInfo.Value = string(s.reader.GetBody())
-	return rootInfo, nil
+	return values.NewText(s.reader.GetBody(), s.ToItem().Name).ToItem(s.cxt.Debug()), nil
 }
 
 /* Copyright 2016-2019 Spiegel

--- a/packet/tags/sub20.go
+++ b/packet/tags/sub20.go
@@ -47,24 +47,21 @@ func (s *sub20) Parse() (*info.Item, error) {
 	if err != nil {
 		return rootInfo, errs.Wrapf(err, "illegal name in parsing sub packet %d (length: %d bytes)", int(s.subID), nameLength)
 	}
-	rootInfo.Add(info.NewItem(
-		info.Name("Name"),
-		info.Value(string(name)),
-	))
+	rootInfo.Add(values.NewText(name, "Name").ToItem(s.cxt.Debug()))
 	value, err := s.reader.ReadBytes(int64(binary.BigEndian.Uint16(valueLength)))
 	if err != nil {
 		return rootInfo, errs.Wrapf(err, "illegal value in parsing sub packet %d (length: %d bytes)", int(s.subID), valueLength)
 	}
-	itm := info.NewItem(
-		info.Name("Value"),
-	)
 	if human != 0x00 {
-		itm.Value = string(value)
+		//human readable data (text)
+		rootInfo.Add(values.NewText(value, "Value").ToItem(s.cxt.Debug()))
 	} else {
-		itm.Dump = values.DumpBytes(value, true).String()
+		//binary data
+		rootInfo.Add(info.NewItem(
+			info.Name("Value"),
+			info.DumpStr(values.DumpBytes(value, true).String()),
+		))
 	}
-	rootInfo.Add(itm)
-
 	return rootInfo, nil
 }
 

--- a/packet/tags/sub24.go
+++ b/packet/tags/sub24.go
@@ -19,9 +19,7 @@ func newSub24(cxt *context.Context, subID values.SuboacketID, body []byte) Subs 
 
 // Parse parsing Preferred Key Server Sub-packet
 func (s *sub24) Parse() (*info.Item, error) {
-	rootInfo := s.ToItem()
-	rootInfo.Value = string(s.reader.GetBody())
-	return rootInfo, nil
+	return values.NewText(s.reader.GetBody(), s.ToItem().Name).ToItem(s.cxt.Debug()), nil
 }
 
 /* Copyright 2016-2019 Spiegel

--- a/packet/tags/sub26.go
+++ b/packet/tags/sub26.go
@@ -19,9 +19,7 @@ func newSub26(cxt *context.Context, subID values.SuboacketID, body []byte) Subs 
 
 // Parse parsing Policy URI Sub-packet
 func (s *sub26) Parse() (*info.Item, error) {
-	rootInfo := s.ToItem()
-	rootInfo.Value = string(s.reader.GetBody())
-	return rootInfo, nil
+	return values.NewText(s.reader.GetBody(), s.ToItem().Name).ToItem(s.cxt.Debug()), nil
 }
 
 /* Copyright 2016-2019 Spiegel

--- a/packet/tags/sub28.go
+++ b/packet/tags/sub28.go
@@ -19,9 +19,7 @@ func newSub28(cxt *context.Context, subID values.SuboacketID, body []byte) Subs 
 
 // Parse parsing Signer's User ID Sub-packet
 func (s *sub28) Parse() (*info.Item, error) {
-	rootInfo := s.ToItem()
-	rootInfo.Value = string(s.reader.GetBody())
-	return rootInfo, nil
+	return values.NewText(s.reader.GetBody(), s.ToItem().Name).ToItem(s.cxt.Debug()), nil
 }
 
 /* Copyright 2016-2019 Spiegel

--- a/packet/tags/tag11.go
+++ b/packet/tags/tag11.go
@@ -34,7 +34,7 @@ func (t *tag11) Parse() (*info.Item, error) {
 	if err != nil {
 		return rootInfo, errs.Wrapf(err, "illegal length of file name in parsing tag %d (length: %d bytes)", int(t.tag), int64(flen))
 	}
-	rootInfo.Add(fname.ToItem(t.cxt.Debug()))
+	rootInfo.Add(fname.ToItem(t.cxt.Literal()))
 	ftime, err := values.NewDateTime(t.reader, t.cxt.UTC())
 	if err != nil {
 		return rootInfo, errs.Wrapf(err, "illegal timestump of file in parsing tag %d", int(t.tag))

--- a/packet/tags/tag11_test.go
+++ b/packet/tags/tag11_test.go
@@ -20,7 +20,7 @@ const (
 	tag11Result1 = `Literal Data Packet (tag 11) (19 bytes)
 	62 00 5a 19 0d e4 48 65 6c 6c 6f 20 77 6f 72 6c 64 0d 0a
 	Literal data format: b (binary)
-	File name: <null>
+	File name (0 byte)
 	Modification time of a file: 2017-11-25T06:29:56Z
 		5a 19 0d e4
 	Literal data (13 bytes)
@@ -79,7 +79,7 @@ func TestTag11(t *testing.T) {
 	}
 }
 
-/* Copyright 2017 Spiegel
+/* Copyright 2017-2019 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packet/tags/tag13.go
+++ b/packet/tags/tag13.go
@@ -20,12 +20,7 @@ func newTag13(cxt *context.Context, tag values.TagID, body []byte) Tags {
 // Parse parsing User ID Packet
 func (t *tag13) Parse() (*info.Item, error) {
 	rootInfo := t.ToItem()
-	body := t.reader.GetBody()
-	rootInfo.Add(info.NewItem(
-		info.Name("User ID"),
-		info.Value(string(body)),
-		info.DumpStr(values.DumpBytes(body, t.cxt.Debug()).String()),
-	))
+	rootInfo.Add(values.NewText(t.reader.GetBody(), "User ID").ToItem(t.cxt.Debug()))
 	return rootInfo, nil
 }
 

--- a/packet/values/literal_test.go
+++ b/packet/values/literal_test.go
@@ -45,36 +45,42 @@ func TestLiteralFname(t *testing.T) {
 	testCases := []struct {
 		data  []byte
 		value string
+		note  string
 		dump  string
 	}{
 		{
 			data:  []byte("hoge"),
 			value: "hoge",
+			note:  "",
 			dump:  "68 6f 67 65",
 		},
 		{
 			data:  []byte("\nhoge"),
 			value: "(U+000A)hoge",
+			note:  "",
 			dump:  "0a 68 6f 67 65",
 		},
 		{
 			data:  []byte{0xff, 0xfe, 0xfd},
-			value: "<invalid text string>",
+			value: "",
+			note:  "invalid text string",
 			dump:  "ff fe fd",
 		},
 		{
 			data:  []byte{},
-			value: "<null>",
+			value: "",
+			note:  "0 byte",
 			dump:  "",
 		},
 		{
 			data:  nil,
-			value: "<null>",
+			value: "",
+			note:  "0 byte",
 			dump:  "",
 		},
 	}
 	for _, tc := range testCases {
-		var l *LiteralFname
+		var l *Text
 		var err error
 		if tc.data == nil {
 			l, err = NewLiteralFname(nil, 0)
@@ -92,8 +98,8 @@ func TestLiteralFname(t *testing.T) {
 		if i.Value != tc.value {
 			t.Errorf("LiteralFname.Value = \"%v\", want \"%v\".", i.Value, tc.value)
 		}
-		if i.Note != "" {
-			t.Errorf("LiteralFname.Note = \"%s\", want \"\"", i.Note)
+		if i.Note != tc.note {
+			t.Errorf("LiteralFname.Note = \"%s\", want \"%v\"", i.Note, tc.note)
 		}
 		if i.Dump != tc.dump {
 			t.Errorf("LiteralFname.Dump = \"%v\", want \"%v\".", i.Dump, tc.dump)


### PR DESCRIPTION
- modified tag11 and tag13 packets
- modified sub06, sub20, sub24, sub26, and sub28 sub-packets