### PR TITLE
docs: add architecture guide and package responsibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This package is required Go 1.26.3 or later.
 - Preserve compatibility of exported symbols when possible.
 - Support OpenPGP extensions incrementally, including RFC 4880bis / RFC 9580.
 
+## Architecture
+
+See [docs/architecture.md](./docs/architecture.md) for package boundaries,
+data flow, and parser extension points.
+
 ## Development
 
 ### Requirements

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture Overview
+
+This document explains internal boundaries and data flow for `gpgpdump`.
+It is intended for maintainers who need to add packet support or refactor code safely.
+
+## Scope
+
+- Target: packet parsing and rendering pipeline, plus CLI orchestration.
+- Non-target: release automation details and end-user command tutorial.
+
+## Package Responsibilities
+
+- `main`: process entry point; wires stdin/stdout/stderr to facade.
+- `facade`: CLI command tree, flag handling, input source selection, output mode selection.
+- `parse`: parser lifecycle, armor detection/decoding, packet iteration.
+- `parse/tags`: packet tag dispatch and tag-specific parse implementation.
+- `parse/result`: output-neutral parse result model (`Info` / `Item`) and text/JSON rendering.
+- `hkp`, `github`, `facade/fetch`: remote key/data acquisition for CLI subcommands.
+
+## Data Flow
+
+1. `main` calls `facade.Execute` with process IO streams.
+2. `facade` builds parse context from flags and selects input source (file, clipboard, stdin).
+3. `parse.New` normalizes input reader (armor-aware).
+4. `Parser.Parse` loops opaque packets and delegates each packet to `parse/tags`.
+5. Tag parsers append structured `result.Item` values into `result.Info`.
+6. `facade` renders the same `result.Info` as plain text or JSON.
+
+## Layer Boundaries
+
+- Parsing logic stays in `parse` and `parse/tags`.
+- CLI-specific concerns stay in `facade` and command files.
+- Output format differences (text vs JSON) must be renderer concerns, not parser concerns.
+- Fetching remote data is isolated from packet parsing.
+
+## Invariants
+
+- The parser should produce one canonical structured result model (`result.Info`).
+- Text and JSON outputs must represent the same parsed information.
+- New RFC support should be additive when possible.
+- Existing CLI flags and exported APIs should remain backward compatible unless explicitly planned.
+
+## RFC 9580 Extension Points
+
+- Add/extend packet handlers in `parse/tags/tag*.go`.
+- Add/extend subpacket handlers in `parse/tags/sub*.go`.
+- Update value mappings in `parse/values` for new identifiers/labels.
+- Keep unknown or unsupported elements observable as structured output instead of silently dropping them.
+
+## Change Checklist
+
+When changing parser/tag behavior:
+
+1. Update or add tests near the affected package.
+2. Verify plain-text and JSON output consistency.
+3. Update `README.md` examples if visible output changed.
+4. Run local checks:
+
+```text
+task test
+task govulncheck
+```

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -22,9 +22,9 @@ import (
 )
 
 var (
-	//Name is applicatin name
+	// Name is application name.
 	Name = "gpgpdump"
-	//Version is version for applicatin
+	// Version is application version.
 	Version = "dev-version"
 )
 
@@ -37,7 +37,7 @@ var (
 	filePath    string
 )
 
-// newRootCmd returns cobra.Command instance for root command
+// newRootCmd builds the CLI command tree and keeps packet decoding in parse packages.
 func newRootCmd(ui *rwi.RWI, args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   Name,
@@ -161,7 +161,7 @@ func parseContext(cmd *cobra.Command) *context.Context {
 	return cxt
 }
 
-// Execute is called from main function
+// Execute is the top-level CLI entry point called from main.
 func Execute(ui *rwi.RWI, args []string) (exit exitcode.ExitCode) {
 	defer func() {
 		//panic hundling

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goark/gpgpdump/facade"
 )
 
+// main keeps process-level IO wiring separate from CLI/parsing logic.
 func main() {
 	facade.Execute(
 		rwi.New(

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goark/gpgpdump/parse/result"
 )
 
-//Parse returns packet result.
+// Parse iterates all packets and returns a single aggregated result model.
 func (p *Parser) Parse() (*result.Info, error) {
 	if p == nil {
 		return result.New(), nil

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -15,13 +15,13 @@ import (
 	"github.com/goark/gpgpdump/parse/tags"
 )
 
-//Parser class for pasing packet
+// Parser holds packet iterator state and accumulated parse results.
 type Parser struct {
 	pct  *tags.Packets
 	info *result.Info
 }
 
-//New returns Parser instance
+// New creates a parser and normalizes input as armor or binary packet stream.
 func New(cxt *context.Context, reader io.Reader) (*Parser, error) {
 	if reader == nil {
 		return nil, errs.Wrap(ecode.ErrNullPointer)
@@ -44,7 +44,7 @@ func New(cxt *context.Context, reader io.Reader) (*Parser, error) {
 	return newParser(cxt, r, result.New())
 }
 
-//NewBytes returns Parser instance
+// NewBytes creates a parser from a byte slice.
 func NewBytes(cxt *context.Context, data []byte) (*Parser, error) {
 	return New(cxt, bytes.NewReader(data))
 }

--- a/parse/result/result.go
+++ b/parse/result/result.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goark/errs"
 )
 
-//Info is information class for OpenPGP packets
+// Info is the root result model for parsed OpenPGP packets.
 type Info struct {
 	Packets []*Item `toml:"Packet,omitempty" json:"Packet,omitempty"`
 }
@@ -20,7 +20,7 @@ func New() *Info {
 	return &Info{}
 }
 
-//Add add item in Packets.
+// Add appends one parsed packet item.
 func (i *Info) Add(a *Item) {
 	if i == nil {
 		return
@@ -30,7 +30,7 @@ func (i *Info) Add(a *Item) {
 	}
 }
 
-//JSON returns JSON formated string
+// JSON serializes the parsed result model.
 func (i *Info) JSON(indent int) (io.Reader, error) {
 	if i == nil {
 		return bytes.NewReader([]byte{}), nil
@@ -43,7 +43,7 @@ func (i *Info) JSON(indent int) (io.Reader, error) {
 	return bytes.NewReader(b), errs.Wrap(err)
 }
 
-//ToString returns string buffer
+// ToString renders the parsed result model as plain text.
 func (i *Info) ToString(indent string) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	if i == nil {
@@ -58,12 +58,12 @@ func (i *Info) ToString(indent string) *bytes.Buffer {
 	return buf
 }
 
-//Stringer as TOML format
+// String renders plain text with tab indentation.
 func (i *Info) String() string {
 	return i.ToString("\t").String()
 }
 
-//Item is information item class
+// Item is one node in the hierarchical packet output model.
 type Item struct {
 	Name  string  `toml:"name" json:"name"`
 	Value string  `toml:"value,omitempty" json:"value,omitempty"`
@@ -72,7 +72,7 @@ type Item struct {
 	Items []*Item `toml:"Item,omitempty" json:"Item,omitempty"`
 }
 
-//ItemOpt is self-referential function for functional options pattern
+// ItemOpt is a functional option for Item.
 type ItemOpt func(*Item)
 
 // NewItem returns a new Item instance
@@ -90,7 +90,7 @@ func (i *Item) optins(opts ...ItemOpt) {
 	}
 }
 
-//Add add sub-item in item.
+// Add appends one child item.
 func (i *Item) Add(a *Item) {
 	if a != nil && i != nil {
 		i.Items = append(i.Items, a)

--- a/parse/tags/tags.go
+++ b/parse/tags/tags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goark/gpgpdump/parse/values"
 )
 
-// tagInfo class as packet result. for all tags
+// tagInfo is a shared base for packet tag parsing results.
 type tagInfo struct {
 	cxt    *context.Context
 	tag    values.TagID
@@ -20,7 +20,7 @@ func (t *tagInfo) ToItem() *result.Item {
 	return t.tag.ToItem(t.reader, t.cxt.Debug())
 }
 
-// Tags parsing interface
+// Tags is the packet-tag parsing interface.
 type Tags interface {
 	Parse() (*result.Item, error)
 }
@@ -65,7 +65,7 @@ var newFunctions = FuncMap{
 	63: newTagPrivate, //Private or Experimental Values
 }
 
-// NewTag returns Tags instance for pasing
+// NewTag dispatches packet tags to tag-specific parser constructors.
 func NewTag(op *packet.OpaquePacket, cxt *context.Context) Tags {
 	if op.Tag == 2 {
 		// recursive call in tag02.Parse() -> sub32.Parse()


### PR DESCRIPTION
## Summary
- add architecture document: `docs/architecture.md`
  - package responsibilities
  - parser/CLI data flow
  - layer boundaries and invariants
  - RFC 9580 extension points
  - change checklist for parser/tag updates
- add README pointer to architecture document
- clarify responsibility comments in key files:
  - `main.go`
  - `facade/facade.go`
  - `parse/parser.go`
  - `parse/parse.go`
  - `parse/tags/tags.go`
  - `parse/result/result.go`

## Why
- make internal structure explicit before larger parser/RFC work
- reduce accidental boundary leaks between CLI and parsing layers
- provide maintainers a single source of truth for extension points

## Notes
- documentation and comments only
- no runtime behavior changes intended