### PR TITLE
fix: avoid panic on invalid parse option resolution

### DIFF
--- a/facade/facade.go
+++ b/facade/facade.go
@@ -190,7 +190,7 @@ func Execute(ui *rwi.RWI, args []string) (exit exitcode.ExitCode) {
 	return
 }
 
-/* Copyright 2017-2025 Spiegel
+/* Copyright 2017-2026 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -48,7 +48,10 @@ func newRootCmd(ui *rwi.RWI, args []string) *cobra.Command {
 			if versionFlag {
 				return debugPrint(ui, errs.Wrap(ui.OutputErrln(getVersion())))
 			}
-			cxt := parseContext(cmd)
+			cxt, err := parseContext(cmd)
+			if err != nil {
+				return debugPrint(ui, err)
+			}
 
 			//open PGP file
 			if cbFlag && len(filePath) > 0 {
@@ -136,29 +139,64 @@ func marshalPacketInfo(i *result.Info) (io.Reader, error) {
 	return i.ToString("\t"), nil
 }
 
-func getBool(cmd *cobra.Command, code context.OptCode) (context.OptCode, bool) {
+// getBool returns a parsed bool flag value for a parse option.
+func getBool(cmd *cobra.Command, code context.OptCode) (context.OptCode, bool, error) {
 	name := code.String()
 	f, err := cmd.Flags().GetBool(name)
 	if err != nil {
-		panic("invalid option: " + name)
+		return code, false, errs.Wrap(ecode.ErrInvalidOption, errs.WithCause(err), errs.WithContext("option", name))
 	}
-	return code, f
+	return code, f, nil
 }
 
-func parseContext(cmd *cobra.Command) *context.Context {
+// parseContext builds parser context from CLI flags.
+func parseContext(cmd *cobra.Command) (*context.Context, error) {
+	armorCode, armor, err := getBool(cmd, context.ARMOR)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	certCode, cert, err := getBool(cmd, context.CERT)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	debugCode, debug, err := getBool(cmd, context.DEBUG)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	integerCode, integer, err := getBool(cmd, context.INTEGER)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	literalCode, literal, err := getBool(cmd, context.LITERAL)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	markerCode, marker, err := getBool(cmd, context.MARKER)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	privateCode, private, err := getBool(cmd, context.PRIVATE)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	utcCode, utc, err := getBool(cmd, context.UTC)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+
 	cxt := context.New(
-		context.Set(getBool(cmd, context.ARMOR)),
-		context.Set(getBool(cmd, context.CERT)),
-		context.Set(getBool(cmd, context.DEBUG)), //for debug
+		context.Set(armorCode, armor),
+		context.Set(certCode, cert),
+		context.Set(debugCode, debug), //for debug
 		//context.Set(getBool(cmd, context.GDUMP)), //not use
-		context.Set(getBool(cmd, context.INTEGER)),
-		context.Set(getBool(cmd, context.LITERAL)),
-		context.Set(getBool(cmd, context.MARKER)),
-		context.Set(getBool(cmd, context.PRIVATE)),
-		context.Set(getBool(cmd, context.UTC)),
+		context.Set(integerCode, integer),
+		context.Set(literalCode, literal),
+		context.Set(markerCode, marker),
+		context.Set(privateCode, private),
+		context.Set(utcCode, utc),
 	)
 	debugFlag = cxt.Debug()
-	return cxt
+	return cxt, nil
 }
 
 // Execute is the top-level CLI entry point called from main.

--- a/facade/fetch.go
+++ b/facade/fetch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newHkpCmd returns cobra.Command instance for show sub-command
+// newFetchCmd returns cobra.Command instance for fetch sub-command.
 func newFetchCmd(ui *rwi.RWI) *cobra.Command {
 	fetchCmd := &cobra.Command{
 		Use:     "fetch [flags] URL",
@@ -19,7 +19,11 @@ func newFetchCmd(ui *rwi.RWI) *cobra.Command {
 		Short:   "Dumps OpenPGP packets form the Web",
 		Long:    "Dumps OpenPGP packets form the Web.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			cxt := parseContext(cmd)
+			cxt, err := parseContext(cmd)
+			if err != nil {
+				err = debugPrint(ui, err)
+				return
+			}
 			//user id
 			if len(args) != 1 {
 				err = debugPrint(ui, errs.Wrap(os.ErrInvalid, errs.WithContext("args", args)))

--- a/facade/github.go
+++ b/facade/github.go
@@ -76,7 +76,7 @@ func newGitHubCmd(ui *rwi.RWI) *cobra.Command {
 	return githubCmd
 }
 
-/* Copyright 2019-2023 Spiegel
+/* Copyright 2019-2026 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/facade/github.go
+++ b/facade/github.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newHkpCmd returns cobra.Command instance for show sub-command
+// newGitHubCmd returns cobra.Command instance for github sub-command.
 func newGitHubCmd(ui *rwi.RWI) *cobra.Command {
 	githubCmd := &cobra.Command{
 		Use:     "github [flags] GitHubUserID",
@@ -22,7 +22,10 @@ func newGitHubCmd(ui *rwi.RWI) *cobra.Command {
 		Short:   "Dumps OpenPGP keys registered on GitHub",
 		Long:    "Dumps OpenPGP keys registered on GitHub.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cxt := parseContext(cmd)
+			cxt, err := parseContext(cmd)
+			if err != nil {
+				return debugPrint(ui, err)
+			}
 			cxt.Set(contxt.ARMOR, true)
 			//user id
 			if len(args) != 1 {

--- a/facade/hkp.go
+++ b/facade/hkp.go
@@ -101,7 +101,7 @@ func newHkpCmd(ui *rwi.RWI) *cobra.Command {
 	return hkpCmd
 }
 
-/* Copyright 2019-2025 Spiegel
+/* Copyright 2019-2026 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/facade/hkp.go
+++ b/facade/hkp.go
@@ -22,7 +22,10 @@ func newHkpCmd(ui *rwi.RWI) *cobra.Command {
 		Short:   "Dumps OpenPGP packets from the key server",
 		Long:    "Dumps OpenPGP packets from the key server.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cxt := parseContext(cmd)
+			cxt, err := parseContext(cmd)
+			if err != nil {
+				return debugPrint(ui, err)
+			}
 			cxt.Set(contxt.ARMOR, true)
 			//user id
 			if len(args) != 1 {

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -69,7 +69,7 @@ func newReaderArmor(r io.Reader) (io.Reader, error) {
 	return block.Body, nil
 }
 
-/* Copyright 2017-2020 Spiegel
+/* Copyright 2017-2026 Spiegel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -23,6 +23,9 @@ type Parser struct {
 
 // New creates a parser and normalizes input as armor or binary packet stream.
 func New(cxt *context.Context, reader io.Reader) (*Parser, error) {
+	if cxt == nil {
+		return nil, errs.Wrap(ecode.ErrInvalidOption, errs.WithContext("context", "nil"))
+	}
 	if reader == nil {
 		return nil, errs.Wrap(ecode.ErrNullPointer)
 	}

--- a/parse/parser_test.go
+++ b/parse/parser_test.go
@@ -1,0 +1,31 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/goark/gpgpdump/ecode"
+)
+
+func TestNewWithNilContext(t *testing.T) {
+	_, err := New(nil, bytes.NewReader([]byte{}))
+	if !errors.Is(err, ecode.ErrInvalidOption) {
+		t.Fatalf("New(nil, reader) error = %v, want %v", err, ecode.ErrInvalidOption)
+	}
+}
+
+/* Copyright 2026 Spiegel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
## Summary
- split changes into two commits:
  1. `chore: update copyright years to 2026`
  2. `fix: return invalid option errors instead of panics`
- change `getBool` to return an error instead of panicking
- change `parseContext` to return `(*context.Context, error)` and propagate errors
- update all callers (`root`, `fetch`, `hkp`, `github`) to handle parse-context errors
- add guard in `parse.New` to return `ErrInvalidOption` when parse context is nil
- add regression test `TestNewWithNilContext`
- tidy function comments for command constructors and context helpers

## Why
- prevent panic-based failure paths for option resolution
- ensure invalid context input is handled as regular errors
- make behavior safer for both CLI and package consumers

## Validation
- `task --force test` passed
- `golangci-lint-v2` passed with 0 issues