### PR TITLE
Add v6-aware version model (RFC 9580 step 1)

### DIFF
--- a/parse/values/version.go
+++ b/parse/values/version.go
@@ -8,14 +8,30 @@ import (
 
 // Version - information version
 type Version struct {
-	ver   byte //version number
-	cur   byte //current version in RFC4880
-	draft byte //draft version in RFC4880bis
+	ver    byte   //version number
+	cur    byte   //current version in RFC4880 (legacy)
+	draft  byte   //draft version in RFC4880bis (legacy)
+	curSet []byte //current versions
+	drfSet []byte //draft versions
 }
 
 // NewVersion returns new Version instance
 func NewVersion(ver, cur, draft byte) *Version {
-	return &Version{ver: ver, cur: cur, draft: draft}
+	return NewVersionSet(ver, []byte{cur}, []byte{draft})
+}
+
+// NewVersionSet returns new Version instance with multiple current/draft candidates.
+func NewVersionSet(ver byte, current, draft []byte) *Version {
+	v := &Version{ver: ver}
+	if len(current) > 0 {
+		v.cur = current[0]
+		v.curSet = append(v.curSet, current...)
+	}
+	if len(draft) > 0 {
+		v.draft = draft[0]
+		v.drfSet = append(v.drfSet, draft...)
+	}
+	return v
 }
 
 // Number returns number of version
@@ -39,12 +55,31 @@ func (v *Version) IsCurrent() bool {
 	if v == nil {
 		return false
 	}
+	if len(v.curSet) > 0 {
+		for _, c := range v.curSet {
+			if v.ver == c {
+				return true
+			}
+		}
+		return false
+	}
 	return v.ver == v.cur
 }
 
 // IsDraft return true if draft version
 func (v *Version) IsDraft() bool {
 	if v == nil {
+		return false
+	}
+	if len(v.drfSet) > 0 {
+		for _, d := range v.drfSet {
+			if d == 0 {
+				continue
+			}
+			if v.ver == d {
+				return true
+			}
+		}
 		return false
 	}
 	if v.draft == 0 {
@@ -88,27 +123,27 @@ func (v *Version) String() string {
 
 // PubVer is Public-Key Packet Version
 func PubVer(ver byte) *Version {
-	return NewVersion(ver, 4, 5)
+	return NewVersionSet(ver, []byte{4, 6}, []byte{5})
 }
 
 // SigVer is Signiture Packet Version
 func SigVer(ver byte) *Version {
-	return NewVersion(ver, 4, 5)
+	return NewVersionSet(ver, []byte{4, 6}, []byte{5})
 }
 
 // OneSigVer is One-Pass Signature Packet Version
 func OneSigVer(ver byte) *Version {
-	return NewVersion(ver, 3, 5)
+	return NewVersionSet(ver, []byte{3, 6}, []byte{5})
 }
 
 // PubSessKeyVer is Public-Key Encrypted Session Key Packet Version
 func PubSessKeyVer(ver byte) *Version {
-	return NewVersion(ver, 3, 5)
+	return NewVersionSet(ver, []byte{3, 6}, []byte{5})
 }
 
 // SymSessKeyVer is Symmetric-Key Encrypted Session Key Packet Version
 func SymSessKeyVer(ver byte) *Version {
-	return NewVersion(ver, 4, 5)
+	return NewVersionSet(ver, []byte{4, 6}, []byte{5})
 }
 
 // AEADPacketVer is AEAD Encrypted Data Packet Version

--- a/parse/values/version_test.go
+++ b/parse/values/version_test.go
@@ -193,6 +193,14 @@ func TestPubVer5(t *testing.T) {
 	}
 }
 
+func TestPubVer6(t *testing.T) {
+	i := PubVer(6).ToItem(true)
+
+	if i.Note != "current" {
+		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
+	}
+}
+
 func TestSigVer5(t *testing.T) {
 	i := SigVer(5).ToItem(true)
 
@@ -203,6 +211,14 @@ func TestSigVer5(t *testing.T) {
 
 func TestSigVer4(t *testing.T) {
 	i := SigVer(4).ToItem(true)
+
+	if i.Note != "current" {
+		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
+	}
+}
+
+func TestSigVer6(t *testing.T) {
+	i := SigVer(6).ToItem(true)
 
 	if i.Note != "current" {
 		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
@@ -225,6 +241,14 @@ func TestOneSigVer5(t *testing.T) {
 	}
 }
 
+func TestOneSigVer6(t *testing.T) {
+	i := OneSigVer(6).ToItem(true)
+
+	if i.Note != "current" {
+		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
+	}
+}
+
 func TestPubSessKeyVer3(t *testing.T) {
 	i := PubSessKeyVer(3).ToItem(true)
 
@@ -241,6 +265,14 @@ func TestPubSessKeyVer5(t *testing.T) {
 	}
 }
 
+func TestPubSessKeyVer6(t *testing.T) {
+	i := PubSessKeyVer(6).ToItem(true)
+
+	if i.Note != "current" {
+		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
+	}
+}
+
 func TestSymSessKeyVer4(t *testing.T) {
 	i := SymSessKeyVer(4).ToItem(true)
 
@@ -254,6 +286,14 @@ func TestSymSessKeyVer5(t *testing.T) {
 
 	if i.Note != "draft" {
 		t.Errorf("Version.Note = \"%v\", want \"draft\"", i.Note)
+	}
+}
+
+func TestSymSessKeyVer6(t *testing.T) {
+	i := SymSessKeyVer(6).ToItem(true)
+
+	if i.Note != "current" {
+		t.Errorf("Version.Note = \"%v\", want \"current\"", i.Note)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend `parse/values.Version` to support multiple current/draft candidates via `NewVersionSet`
- keep backward compatibility by preserving `NewVersion(ver, cur, draft)` as a delegating constructor
- update packet version helpers to treat v6 as `current` while keeping v5 as `draft`
- add tests for v6 classification in public key, signature, one-pass signature, PKESK, and SKESK helpers

## Validation
- `go test ./parse/values`
- `task --force test`