### PR TITLE
Fix tag04 output label for one-pass signature chain

### DIFF
--- a/parse/tags/tag04.go
+++ b/parse/tags/tag04.go
@@ -81,7 +81,7 @@ func (t *tag04) parseV3(rootInfo *result.Item) (*result.Item, error) {
 		f = "another one pass signature"
 	}
 	rootInfo.Add(result.NewItem(
-		result.Name("Encrypted session key"),
+		result.Name("One-pass signature chain"),
 		result.Value(f),
 		result.Note(fmt.Sprintf("flag %#02x", flag)),
 	))
@@ -135,7 +135,7 @@ func (t *tag04) parseV5(rootInfo *result.Item) (*result.Item, error) {
 		f = "another one pass signature"
 	}
 	rootInfo.Add(result.NewItem(
-		result.Name("Encrypted session key"),
+		result.Name("One-pass signature chain"),
 		result.Value(f),
 		result.Note(fmt.Sprintf("flag %#02x", flag)),
 	))

--- a/parse/tags/tag04_test.go
+++ b/parse/tags/tag04_test.go
@@ -25,7 +25,7 @@ const (
 	Public-key Algorithm: DSA (Digital Signature Algorithm) (pub 17)
 		11
 	Key ID: 0xb4da3bae7e20b81c
-	Encrypted session key: other than one pass signature (flag 0x01)
+	One-pass signature chain: other than one pass signature (flag 0x01)
 `
 )
 


### PR DESCRIPTION
## Summary
- rename the tag04 output item label from `Encrypted session key` to `One-pass signature chain`
- keep existing flag value semantics unchanged
- update text expectation in tag04 test output

## Validation
- `go test ./parse/tags`
- `task --force test`