### PR TITLE
Align wording with RFC 9580 and LibrePGP draft policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/goark/gpgpdump/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/goark/gpgpdump.svg)](https://github.com/goark/gpgpdump/releases/latest)
 
-[gpgpdump] is a OpenPGP ([RFC 4880]) packet visualizer by [golang](https://golang.org/).
+[gpgpdump] is an OpenPGP ([RFC 9580]) packet visualizer by [golang](https://golang.org/).
 
 - Command-line interface, based on [pgpdump](https://github.com/kazu-yamamoto/pgpdump) design by [kazu-yamamoto](https://github.com/kazu-yamamoto).
 - Output with plain text or [JSON](https://tools.ietf.org/html/rfc7159)-formatted text
-- Support [RFC 5581] and [RFC 6637]
-- Support a part of [RFC 4880bis]
+- Support OpenPGP packet parsing based on [RFC 9580]
+- Support a part of [LibrePGP (draft)]
 
 This package is required Go 1.26.3 or later.
 
@@ -22,7 +22,7 @@ This package is required Go 1.26.3 or later.
 - Keep packet dump behavior deterministic and stable.
 - Keep CLI options explicit for local files and command inputs.
 - Preserve compatibility of exported symbols when possible.
-- Support OpenPGP extensions incrementally, including RFC 4880bis / RFC 9580.
+- Support OpenPGP extensions incrementally, including RFC 9580 and LibrePGP draft work.
 
 ## Architecture
 
@@ -102,7 +102,7 @@ cat testdata/eccsig.asc | gpgpdump -j -u | jq .
 
 ```
 $ gpgpdump -h
-OpenPGP (RFC 4880) packet visualizer by golang.
+OpenPGP (RFC 9580) packet visualizer by golang.
 
 Usage:
   gpgpdump [flags]
@@ -389,7 +389,5 @@ This project wraps internal errors with `github.com/goark/errs`.
 [![dependency.png](./dependency.png)](./dependency.png)
 
 [gpgpdump]: https://github.com/goark/gpgpdump "goark/gpgpdump: gpgpdump - OpenPGP packet visualizer"
-[RFC 4880]: https://tools.ietf.org/html/rfc4880
-[RFC 4880bis]: https://datatracker.ietf.org/doc/draft-ietf-openpgp-rfc4880bis/
-[RFC 5581]: http://tools.ietf.org/html/rfc5581
-[RFC 6637]: http://tools.ietf.org/html/rfc6637
+[RFC 9580]: https://www.rfc-editor.org/rfc/rfc9580.html
+[LibrePGP (draft)]: https://datatracker.ietf.org/doc/draft-koch-librepgp/

--- a/docs/rfc9580-coverage.md
+++ b/docs/rfc9580-coverage.md
@@ -1,14 +1,15 @@
 # RFC 9580 Coverage (Current State)
 
 This note summarizes current implementation status for features related to
-RFC 4880, RFC 5581, RFC 6637, and RFC 9580.
+RFC 9580 and LibrePGP (draft).
 
 ## Summary
 
-- Stable base support is present for RFC 4880, RFC 5581, and RFC 6637.
+- Stable base support is present for packet forms standardized in RFC 9580.
 - RFC 9580-related parser paths are partially implemented, including key version
   6 routing in major packet families.
-- Remaining work is mostly policy and corpus expansion (wording, vectors, docs).
+- Version wording policy is now fixed: v4/v6 are `current`, v5 is `draft`.
+- Remaining work is mostly corpus expansion and user-facing docs sync.
 
 ## Implemented (Confirmed)
 
@@ -57,30 +58,27 @@ RFC 4880, RFC 5581, RFC 6637, and RFC 9580.
 - Focused and route-level tests for v6 key-version behavior are present.
   - parse/tags/key_version_test.go
 
+7. Version wording policy (finalized)
+- v4 and v6 are treated as `current` packet versions.
+  - v4 is treated as current in this project policy.
+  - v6 aligns with RFC 9580.
+- v5 is treated as `draft` for compatibility policy reasons.
+  - RFC 9580 does not assign v5 packet versions.
+  - v5 remains associated with ongoing LibrePGP draft discussions.
+
 ## Partial / Inconsistent
 
-1. Draft-oriented wording remains in output and tests
-- Version 5 is still labeled as "draft" in output.
-  - parse/values/version.go
-- Existing expected outputs keep draft wording where v5 packets are used.
-  - parse/tags/tag05_test.go
-  - parse/tags/tag07_test.go
-
-2. Real-world v6 vector coverage is still narrow
+1. Real-world v6 vector coverage is still narrow
 - Current v6 tests are mostly focused/minimal route checks.
 - Larger corpus vectors and realistic packet snapshots are still desirable.
 
 ## Remaining Gaps (Likely Next PR Units)
 
-1. Decide and document v5/v6 wording policy
-- Keep "draft" for v5 or move to neutral/stable wording depending on project
-  compatibility policy.
-
-2. Expand v6 test corpus
+1. Expand v6 test corpus
 - Add realistic vectors for signature, key, and encrypted packet families.
 - Prefer fixture-based tests where feasible.
 
-3. Sync user-facing docs
+2. Sync user-facing docs
 - Keep README and architecture notes aligned with current parser behavior and
   RFC 9580 scope.
 

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -42,7 +42,7 @@ func newRootCmd(ui *rwi.RWI, args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   Name,
 		Short: "OpenPGP packet visualizer",
-		Long:  "OpenPGP (RFC 4880) packet visualizer by golang.",
+		Long:  "OpenPGP (RFC 9580) packet visualizer by golang.",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			//options options
 			if versionFlag {

--- a/parse/values/version.go
+++ b/parse/values/version.go
@@ -121,6 +121,11 @@ func (v *Version) String() string {
 	return strconv.Itoa(int(v.ver))
 }
 
+// Project policy:
+//   - v4/v6 are treated as current OpenPGP packet versions.
+//   - v5 is treated as draft to keep it distinct from RFC 9580 and aligned with
+//     ongoing LibrePGP draft discussions.
+
 // PubVer is Public-Key Packet Version
 func PubVer(ver byte) *Version {
 	return NewVersionSet(ver, []byte{4, 6}, []byte{5})


### PR DESCRIPTION
## Summary
- update user-facing wording to reference RFC 9580 and LibrePGP (draft)
- remove obsolete explicit RFC 4880/5581/6637/4880bis references from README and coverage note
- align CLI long description text with RFC 9580 wording
- keep version policy explicit: v4/v6 as current, v5 as draft

## Validation
- `task` (default task)
  - tests: pass
  - lint: 0 issues
  - govulncheck: no vulnerabilities