### PR TITLE
Add contributor workflow guide and Copilot PR flow rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ It supports plain-text and JSON output for packet inspection and debugging.
 ## Scope and compatibility
 
 - Keep behavior compatible with existing RFC 4880 packet parsing unless the change is explicitly for new spec support.
-- Treat RFC 4880bis / RFC 9580 related changes as additive when possible.
+- Treat RFC 9580 and LibrePGP draft related changes as additive when possible.
 - Avoid breaking exported APIs and CLI flags without clear migration notes.
 
 ## Architecture overview
@@ -36,10 +36,15 @@ Keep parsing logic in parser/tag packages and avoid pushing protocol details int
 ## Testing and validation
 
 - Add or update tests for parser and tag behavior changes.
-- Prefer local validation with Taskfile targets:
-  - `task test`
-  - `task govulncheck`
+- Prefer local validation with Taskfile. Use `task` (no arguments) as the default full check.
 - For parser-focused changes, run narrow package tests first, then full validation.
+
+## Pull request workflow
+
+- Use small, focused PR units. Avoid bundling unrelated changes.
+- Before creating a PR, run local validation with `task` by default.
+- After CI checks pass, merge to `master` and delete both remote and local working branches.
+- If GitHub Actions is degraded/stuck, prefer waiting for recovery; if needed, retrigger checks with a minimal empty commit.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for contributing to `gpgpdump`.
+
+## Development flow
+
+1. Create a small, focused branch from `master`.
+2. Keep each PR limited to one topic.
+3. Run local checks with:
+
+```bash
+task
+```
+
+4. Open a PR and wait for `ci` and `CodeQL` checks to pass.
+5. Merge to `master`.
+6. Delete the working branch on both remote and local.
+
+## Coding and review policy
+
+- Keep parser logic in `parse/` and `parse/tags/`.
+- Avoid broad refactors unrelated to the target change.
+- Keep comments concise and in English.
+- Preserve compatibility of exported APIs and CLI flags unless a change is intentional and documented.
+
+## Spec policy
+
+- Treat RFC 9580 packet behavior as current OpenPGP behavior.
+- Treat version 5 packet behavior as draft policy in this project.
+- Handle RFC 9580 and LibrePGP draft differences additively when practical.
+
+## Testing guidance
+
+- Prefer adding or updating tests together with behavior changes.
+- For parser-specific work, run narrow package tests first, then run `task`.
+
+## Troubleshooting CI
+
+- If GitHub Actions is degraded, wait for status recovery first.
+- If checks stay queued after recovery, retrigger runs (for example, by pushing a minimal empty commit).


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with project contribution flow, validation steps, and CI troubleshooting notes
- update `.github/copilot-instructions.md` with explicit PR workflow rules
- set default local full-check command to `task` (no arguments)
- align spec wording in Copilot instructions with RFC 9580 and LibrePGP draft

## Validation
- doc-focused update (workflow guidance only)
- existing project validation command for full checks: `task`